### PR TITLE
added start and end keys in the opts for createReadStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you pass a string instead of an options map it will be used as the `path` as 
 
 #### `var readStream = store.createReadStream(opts)`
 
-Open a read stream to a blob. `opts` must have a `key` key with the hash of the blob you want to read.
+Open a read stream to a blob. `opts` must have a `key` key with the hash of the blob you want to read. `opts` can optionally contain a `start` or `end` key if you only want part of the blob.
 
 #### `var writeStream = store.createWriteStream([cb])`
 

--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ module.exports = function(opts) {
 
   that.createReadStream = function(opts) {
     if (typeof opts === 'string') opts = {key:opts}
-    return fs.createReadStream(toPath(dir, opts.key || opts.hash))
+    return fs.createReadStream(toPath(dir, opts.key || opts.hash), opts)
   }
 
   that.exists = function(opts, cb) {

--- a/test.js
+++ b/test.js
@@ -38,3 +38,22 @@ test('remove file', function(t) {
     })
   })
 })
+
+test('seek blob', function(t) {
+  common.setup(t, function(err, store) {
+    var w = store.createWriteStream()
+    w.write('hello')
+    w.write('world')
+    w.end(function() {
+      var buff = ""
+      var blob = store.createReadStream({ key: w.key, start: 5 })
+      blob.on('data', function (data) { buff += data })
+      blob.on('end', function () {
+        t.equal(buff, 'world')
+        common.teardown(t, null, null, function(err) {
+          t.end()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
I find that if I don't need the entire blob, say for a large video file, it is useful to specify a start or end position. This isn't part of the api for [abtract-blob-store](https://github.com/maxogden/abstract-blob-store#storecreatereadstreamopts), but the api seems open ended, and it is something I find useful especially for large blobs.

Any thoughts?