### PR TITLE
Add tmpdir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Creates a new instance. Opts should have a `path` property to where the blobs sh
 You can also specify a node `crypto` module hashing algorithm to use using the `algo` key in options. The default is `sha256`.
 If you pass a string instead of an options map it will be used as the `path` as well.
 
+The `tmpdir` option can be used to specify the directory where files are stored temporarily during writing. The default is `os.tmpdir()`.
+
 #### `var readStream = store.createReadStream(opts)`
 
 Open a read stream to a blob. `opts` must have a `key` key with the hash of the blob you want to read. `opts` can optionally contain a `start` or `end` key if you only want part of the blob.

--- a/index.js
+++ b/index.js
@@ -94,10 +94,12 @@ module.exports = function(opts) {
   var dir = opts.dir || opts.path
   if (!dir) dir = path.join(process.cwd(), 'blobs')
 
+  var tmpdir = opts.tmpdir || (os.tmpdir || os.tmpDir)()
+
   var that = {}
 
   var init = thunky(function(cb) {
-    var tmp = path.join((os.tmpdir || os.tmpDir)(), 'cabs')
+    var tmp = path.join(tmpdir, 'cabs')
     mkdirp(tmp, function() {
       mkdirp(dir, function() {
         cb(tmp)


### PR DESCRIPTION
We started seeing this error from `fs.rename` after #11 was merged, because `/tmp/` was a separate filesystem to where the files are actually stored:

> EXDEV: cross-device link not permitted

This commit adds a `tmpdir` option so that we can specify an alternate tmp directory that is on the same filesystem as the data directory.