### PR TITLE
Refresh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: node_js
 node_js: node
+dist: xenial
 script:
 - npm test
 - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+---
 language: node_js
 node_js:
-  - "0.10"
+- '0.10'
+script:
+- npm test
+- npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: node_js
-node_js:
-- '0.10'
+node_js: node
 script:
 - npm test
 - npm run lint

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var w = store.createWriteStream()
 w.write('hello ')
 w.write('world\n')
 
-w.end(function() {
+w.end(function () {
   console.log('blob written: '+w.key)
   store.createReadStream(w).pipe(process.stdout)
 })

--- a/example.js
+++ b/example.js
@@ -1,12 +1,12 @@
 var blobs = require('./')
-var store = blobs({path: './data'})
+var store = blobs({ path: './data' })
 
 var w = store.createWriteStream()
 
 w.write('hello ')
 w.write('world\n')
 
-w.end(function() {
-  console.log('blob written: '+w.key)
+w.end(function () {
+  console.log('blob written: ' + w.key)
   store.createReadStream(w).pipe(process.stdout)
 })

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = function (opts) {
   var dir = opts.dir || opts.path
   if (!dir) dir = path.join(process.cwd(), 'blobs')
 
-  var tmpdir = (opts.tmpdir || os.tmpdir)()
+  var tmpdir = (opts.tmpdir || os.tmpdir())
 
   var that = {}
 

--- a/index.js
+++ b/index.js
@@ -8,15 +8,15 @@ var os = require('os')
 var mkdirp = require('mkdirp')
 var thunky = require('thunky')
 
-var noop = function() {}
+var noop = function () {}
 
-var SIGNAL_FLUSH = new Buffer([0])
+var SIGNAL_FLUSH = Buffer.from([0])
 
-var toPath = function(base, hash) {
+var toPath = function (base, hash) {
   return hash ? path.join(base, hash.slice(0, 2), hash.slice(2)) : base
 }
 
-var Writer = function(dir, algo, init) {
+var Writer = function (dir, algo, init) {
   this.key = null
   this.size = 0
   this.destroyed = false
@@ -32,27 +32,27 @@ var Writer = function(dir, algo, init) {
 
 util.inherits(Writer, stream.Writable)
 
-Writer.prototype._flush = function(cb) {
+Writer.prototype._flush = function (cb) {
   var self = this
   var hash = this.key = this._digest.digest('hex')
   var dir = path.join(this._directory, hash.slice(0, 2))
 
-  self._ws.end(function() {
-    fs.mkdir(dir, function() {
+  self._ws.end(function () {
+    fs.mkdir(dir, function () {
       fs.rename(self._tmp, toPath(self._directory, hash), cb)
     })
   })
 }
 
-Writer.prototype._setup = function(data, enc, cb) {
+Writer.prototype._setup = function (data, enc, cb) {
   var self = this
-  var destroy = function(err) {
+  var destroy = function (err) {
     self.destroy(err)
   }
 
-  this._init(function(dir) {
+  this._init(function (dir) {
     if (self.destroyed) return cb(new Error('stream destroyed'))
-    self._tmp = path.join(dir, Date.now()+'-'+Math.random().toString().slice(2))
+    self._tmp = path.join(dir, Date.now() + '-' + Math.random().toString().slice(2))
     self._ws = fs.createWriteStream(self._tmp)
     self._ws.on('error', destroy)
     self._ws.on('close', destroy)
@@ -60,7 +60,7 @@ Writer.prototype._setup = function(data, enc, cb) {
   })
 }
 
-Writer.prototype.destroy = function(err) {
+Writer.prototype.destroy = function (err) {
   if (this.destroyed) return
   this.destroyed = true
   if (this._ws) this._ws.destroy()
@@ -68,7 +68,7 @@ Writer.prototype.destroy = function(err) {
   this.emit('close')
 }
 
-Writer.prototype._write = function(data, enc, cb) {
+Writer.prototype._write = function (data, enc, cb) {
   if (!this._tmp) return this._setup(data, enc, cb)
   if (data === SIGNAL_FLUSH) return this._flush(cb)
   this.size += data.length
@@ -76,7 +76,7 @@ Writer.prototype._write = function(data, enc, cb) {
   this._ws.write(data, enc, cb)
 }
 
-Writer.prototype.end = function(data, enc, cb) {
+Writer.prototype.end = function (data, enc, cb) {
   if (typeof data === 'function') return this.end(null, null, data)
   if (typeof enc === 'function') return this.end(data, null, enc)
   if (data) this.write(data)
@@ -84,8 +84,8 @@ Writer.prototype.end = function(data, enc, cb) {
   stream.Writable.prototype.end.call(this, cb)
 }
 
-module.exports = function(opts) {
-  if (typeof opts === 'string') opts = {path: opts}
+module.exports = function (opts) {
+  if (typeof opts === 'string') opts = { path: opts }
   if (!opts) opts = {}
 
   var algo = opts.algo
@@ -94,27 +94,27 @@ module.exports = function(opts) {
   var dir = opts.dir || opts.path
   if (!dir) dir = path.join(process.cwd(), 'blobs')
 
-  var tmpdir = opts.tmpdir || (os.tmpdir || os.tmpDir)()
+  var tmpdir = (opts.tmpdir || os.tmpdir)()
 
   var that = {}
 
-  var init = thunky(function(cb) {
+  var init = thunky(function (cb) {
     var tmp = path.join(tmpdir, 'cabs')
-    mkdirp(tmp, function() {
-      mkdirp(dir, function() {
+    mkdirp(tmp, function () {
+      mkdirp(dir, function () {
         cb(tmp)
       })
     })
   })
 
-  that.createWriteStream = function(opts, cb) {
-    if (typeof opts === 'string') opts = {key:opts}
+  that.createWriteStream = function (opts, cb) {
+    if (typeof opts === 'string') opts = { key: opts }
     if (typeof opts === 'function') return that.createWriteStream(null, opts)
 
     var ws = new Writer(dir, algo, init)
     if (!cb) return ws
 
-    eos(ws, function(err) {
+    eos(ws, function (err) {
       if (err) return cb(err)
       cb(null, {
         key: ws.key,
@@ -125,34 +125,34 @@ module.exports = function(opts) {
     return ws
   }
 
-  that.createReadStream = function(opts) {
-    if (typeof opts === 'string') opts = {key:opts}
+  that.createReadStream = function (opts) {
+    if (typeof opts === 'string') opts = { key: opts }
     return fs.createReadStream(toPath(dir, opts.key || opts.hash), opts)
   }
 
-  that.exists = function(opts, cb) {
-    if (typeof opts === 'string') opts = {key:opts}
-    fs.stat(toPath(dir, opts.key), function(err, stat) {
+  that.exists = function (opts, cb) {
+    if (typeof opts === 'string') opts = { key: opts }
+    fs.stat(toPath(dir, opts.key), function (err, stat) {
       if (err && err.code === 'ENOENT') return cb(null, false)
       if (err) return cb(err)
       cb(null, true)
     })
   }
 
-  that.remove = function(opts, cb) {
+  that.remove = function (opts, cb) {
     if (!cb) cb = noop
-    if (typeof opts === 'string') opts = {key:opts}
-    fs.unlink(toPath(dir, opts.key), function(err) {
+    if (typeof opts === 'string') opts = { key: opts }
+    fs.unlink(toPath(dir, opts.key), function (err) {
       if (err && err.code === 'ENOENT') return cb(null, false)
       if (err) return cb(err)
       cb(null, true)
     })
   }
 
-  that.resolve = function(opts, cb) {
-    if (typeof opts === 'string') opts = {key:opts}
+  that.resolve = function (opts, cb) {
+    if (typeof opts === 'string') opts = { key: opts }
     var path = toPath(dir, opts.key)
-    fs.stat(path, function(err, stat) {
+    fs.stat(path, function (err, stat) {
       if (err && err.code === 'ENOENT') return cb(null, false, null)
       if (err) return cb(err)
       cb(null, path, stat)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "abstract-blob-store": "^3.2.0",
     "concat-stream": "^1.4.6",
     "rimraf": "^2.2.8",
-    "tape": "^2.13.4"
+    "tape": "^4.11.0"
   },
   "scripts": {
     "test": "tape test.js"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "abstract-blob-store": "^3.2.0",
-    "concat-stream": "^1.4.6",
+    "concat-stream": "^2.0.0",
     "rimraf": "^2.2.8",
     "tape": "^4.11.0"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "end-of-stream": "^1.0.0",
     "mkdirp": "^0.5.0",
     "readable-stream": "^1.0.31",
-    "thunky": "^0.1.0"
+    "thunky": "^1.0.3"
   },
   "devDependencies": {
     "abstract-blob-store": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "test": "tape test.js",
-    "lint": "standard && standard-markdown README.md"
+    "lint": "standard ; standard-markdown README.md"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "end-of-stream": "^1.0.0",
     "mkdirp": "^0.5.0",
-    "readable-stream": "^1.0.31",
+    "readable-stream": "^3.4.0",
     "thunky": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "thunky": "^1.0.3"
   },
   "devDependencies": {
-    "abstract-blob-store": "^3.2.0",
+    "abstract-blob-store": "^3.3.5",
     "concat-stream": "^2.0.0",
     "rimraf": "^2.2.8",
     "standard": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,13 @@
     "abstract-blob-store": "^3.2.0",
     "concat-stream": "^2.0.0",
     "rimraf": "^2.2.8",
+    "standard": "^13.1.0",
+    "standard-markdown": "^5.1.0",
     "tape": "^4.11.0"
   },
   "scripts": {
-    "test": "tape test.js"
+    "test": "tape test.js",
+    "lint": "standard && standard-markdown README.md"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -7,32 +7,34 @@ var rimraf = require('rimraf')
 var abstractBlobTests = require('abstract-blob-store/tests')
 
 var blobs = require('./')
-var blobPath = path.join((os.tmpdir || os.tmpDir)(), 'fs-blob-store-tests')
+var blobPath = path.join(os.tmpdir(), 'fs-blob-store-tests')
 
 var common = {
-  setup: function(t, cb) {
-    rimraf(blobPath, function() {
-      var store = blobs({path: blobPath})
+  setup: function (t, cb) {
+    rimraf(blobPath, function () {
+      var store = blobs({ path: blobPath })
       cb(null, store)
     })
   },
-  teardown: function(t, store, blob, cb) {
+  teardown: function (t, store, blob, cb) {
     rimraf(blobPath, cb)
   }
 }
 
 abstractBlobTests(test, common)
 
-test('remove file', function(t) {
-  common.setup(t, function(err, store) {
+test('remove file', function (t) {
+  common.setup(t, function (err, store) {
+    t.ifError(err, 'no error')
     var w = store.createWriteStream()
     w.write('hello')
     w.write('world')
-    w.end(function() {
-      store.remove(w, function(err, deleted) {
+    w.end(function () {
+      store.remove(w, function (err, deleted) {
         t.notOk(err, 'no err')
         t.ok(deleted, 'was deleted')
-        common.teardown(t, null, null, function(err) {
+        common.teardown(t, null, null, function (err) {
+          t.ifError(err, 'no error')
           t.end()
         })
       })
@@ -40,18 +42,20 @@ test('remove file', function(t) {
   })
 })
 
-test('seek blob', function(t) {
-  common.setup(t, function(err, store) {
+test('seek blob', function (t) {
+  common.setup(t, function (err, store) {
+    t.ifError(err, 'no error')
     var w = store.createWriteStream()
     w.write('hello')
     w.write('world')
-    w.end(function() {
-      var buff = ""
+    w.end(function () {
+      var buff = ''
       var blob = store.createReadStream({ key: w.key, start: 5 })
       blob.on('data', function (data) { buff += data })
       blob.on('end', function () {
         t.equal(buff, 'world')
-        common.teardown(t, null, null, function(err) {
+        common.teardown(t, null, null, function (err) {
+          t.ifError(err, 'no error')
           t.end()
         })
       })
@@ -59,23 +63,24 @@ test('seek blob', function(t) {
   })
 })
 
-
-test('resolve blob', function(t) {
-  common.setup(t, function(err, store) {
+test('resolve blob', function (t) {
+  common.setup(t, function (err, store) {
+    t.ifError(err, 'no error')
     var w = store.createWriteStream()
     w.write('hello')
     w.write('world')
-    w.end(function() {
-      var buff = ""
-      store.resolve({key: w.key}, function (err, path, stat) {
+    w.end(function () {
+      store.resolve({ key: w.key }, function (err, path, stat) {
         t.error(err, 'no error')
         t.notEqual(path, false, 'path should not be false')
         t.notEqual(stat, null, 'path is not null')
         t.true(stat instanceof fs.Stats, 'stat is instanceof Stats')
         store.resolve('foo', function (err, path, stat) {
+          t.ifError(err, 'no error')
           t.equal(path, false, 'path should be false for missing key')
           t.equal(stat, null, 'path is null for missing key')
-          common.teardown(t, null, null, function(err) {
+          common.teardown(t, null, null, function (err) {
+            t.ifError(err, 'no error')
             t.end()
           })
         })


### PR DESCRIPTION
@mafintosh, this PR:

- bumps dependencies
- adopts Standard style
- addresses Standard lint errors
- configures Travis CI to test on latest Node.js

There is an abstract-blob-store test failure: When a file isn't found, `.notFound` isn't set on the `ENOENT` error.  I couldn't think of a good way to wrap emission of that error offhand. Perhaps you can.